### PR TITLE
Rewrite ASCII converter to use traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In this example I set framerate to 24 (but you can use any another)
 
 ## Examples
 
-| Original                                         | ASCII                                               | ASCII colored                                              | Pixels                                                       |
-| ------------------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ |
-| ![Original Image](assets/examples/original.webp) | ![ASCII image](assets/examples/ascii.webp)          | ![ASCII colored image](assets/examples/ascii-colored.webp) | ![Image using pixels (█)](assets/examples/ascii-pixels.webp) |
-| `Original image`                                 | `tapciify -i ./assets/examples/original.webp -w 64` | `tapciify -i ./assets/examples/original.webp -w 64 -c`     | `tapciify -i ./assets/examples/original.webp -w 64 --pixels` |
+| Original                                         | ASCII                                               | ASCII colored                                            | Pixels                                                                  |
+| ------------------------------------------------ | --------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------- |
+| ![Original Image](assets/examples/original.webp) | ![ASCII art](assets/examples/ascii.webp)            | ![ASCII colored art](assets/examples/ascii-colored.webp) | ![ASCII art using pixels (█ symbol)](assets/examples/ascii-pixels.webp) |
+| `Original image`                                 | `tapciify -i ./assets/examples/original.webp -w 64` | `tapciify -i ./assets/examples/original.webp -w 64 -c`   | `tapciify -i ./assets/examples/original.webp -w 64 --pixels`            |

--- a/examples/colored.rs
+++ b/examples/colored.rs
@@ -1,6 +1,8 @@
 use image::imageops::FilterType;
 use std::error::Error;
-use tapciify::{AsciiConverter, AsciiConverterOptions, CustomRatioResize, DEFAULT_FONT_RATIO};
+use tapciify::{
+    AsciiArtConverter, AsciiArtConverterOptions, CustomRatioResize, DEFAULT_FONT_RATIO,
+};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let orig_img = image::open("./assets/examples/original.webp")?;
@@ -8,13 +10,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let img =
         orig_img.resize_custom_ratio(Some(64), None, DEFAULT_FONT_RATIO, FilterType::Triangle);
 
-    let options = AsciiConverterOptions {
+    let options = AsciiArtConverterOptions {
         // Put your other options here
         colored: true,
         ..Default::default()
     };
 
-    let result = AsciiConverter::convert(&img, &options)?;
+    let result = img.ascii_art(&options)?;
 
     println!("{}", result.text);
 

--- a/examples/colored.rs
+++ b/examples/colored.rs
@@ -5,20 +5,17 @@ use tapciify::{
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let orig_img = image::open("./assets/examples/original.webp")?;
+    let img = image::open("./assets/examples/original.webp")?;
 
-    let img =
-        orig_img.resize_custom_ratio(Some(64), None, DEFAULT_FONT_RATIO, FilterType::Triangle);
+    let result = img
+        .resize_custom_ratio(Some(64), None, DEFAULT_FONT_RATIO, FilterType::Triangle)
+        .ascii_art(&AsciiArtConverterOptions {
+            // Put your other options here
+            colored: true,
+            ..Default::default()
+        })?;
 
-    let options = AsciiArtConverterOptions {
-        // Put your other options here
-        colored: true,
-        ..Default::default()
-    };
-
-    let result = img.ascii_art(&options)?;
-
-    println!("{}", result.text);
+    println!("{}", result);
 
     Ok(())
 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,6 +1,8 @@
 use image::imageops::FilterType;
 use std::error::Error;
-use tapciify::{AsciiConverter, AsciiConverterOptions, CustomRatioResize, DEFAULT_FONT_RATIO};
+use tapciify::{
+    AsciiArtConverter, AsciiArtConverterOptions, CustomRatioResize, DEFAULT_FONT_RATIO,
+};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let orig_img = image::open("./assets/examples/original.webp")?;
@@ -8,12 +10,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let img =
         orig_img.resize_custom_ratio(Some(64), None, DEFAULT_FONT_RATIO, FilterType::Triangle);
 
-    let options = AsciiConverterOptions {
+    let options = AsciiArtConverterOptions {
         // Put your other options here
         ..Default::default()
     };
 
-    let result = AsciiConverter::convert(&img, &options)?;
+    let result = img.ascii_art(&options)?;
 
     println!("{}", result.text);
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -5,19 +5,16 @@ use tapciify::{
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let orig_img = image::open("./assets/examples/original.webp")?;
+    let img = image::open("./assets/examples/original.webp")?;
 
-    let img =
-        orig_img.resize_custom_ratio(Some(64), None, DEFAULT_FONT_RATIO, FilterType::Triangle);
+    let result = img
+        .resize_custom_ratio(Some(64), None, DEFAULT_FONT_RATIO, FilterType::Triangle)
+        .ascii_art(&AsciiArtConverterOptions {
+            // Put your other options here
+            ..Default::default()
+        })?;
 
-    let options = AsciiArtConverterOptions {
-        // Put your other options here
-        ..Default::default()
-    };
-
-    let result = img.ascii_art(&options)?;
-
-    println!("{}", result.text);
+    println!("{}", result);
 
     Ok(())
 }

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -4,13 +4,13 @@
 //!
 //! ## Demo
 //!
-//! ```ignore
+//! ```
 #![doc = include_str!("../examples/demo.rs")]
 //! ```
 //!
 //! ## Colored
 //!
-//! ```ignore
+//! ```
 #![doc = include_str!("../examples/demo.rs")]
 //! ```
 
@@ -33,7 +33,7 @@ pub const DEFAULT_ASCII_STRING: &str = " .,:;+*?%S#@";
 /// # Examples
 ///
 /// ```
-/// use tapciify::get_lightness;
+/// use tapciify::ascii::get_lightness;
 ///
 /// let result = get_lightness(255, 255, 255, 255);
 /// assert_eq!(result, 1.0);
@@ -66,12 +66,12 @@ impl fmt::Display for AsciiStringError {
 
 impl Error for AsciiStringError {}
 
-/// Convert lightness of pixel to ASCII character
+/// Convert lightness of pixel to [`char`]
 ///
 /// # Examples
 ///
 /// ```
-/// use tapciify::ascii_character;
+/// use tapciify::ascii::ascii_character;
 ///
 /// let ascii_string = " *#";
 ///
@@ -92,7 +92,7 @@ pub fn ascii_character(lightness: f32, ascii_string: &str) -> Result<char, Ascii
         .ok_or(AsciiStringError)
 }
 
-/// ASCII character of RawAsciiImage
+/// ASCII pixel of [`AsciiArt`]
 #[derive(Debug, Clone)]
 pub struct AsciiArtPixel {
     pub character: char,
@@ -145,42 +145,52 @@ impl AsciiArtPixel {
 
 /// Raw ASCII art conversion result
 #[derive(Debug, Clone)]
-pub struct RawAsciiArt {
+pub struct AsciiArt {
     pub characters: Vec<AsciiArtPixel>,
     pub width: u32,
     pub height: u32,
     pub colored: bool,
 }
 
-impl RawAsciiArt {
-    pub fn new(
-        characters: Vec<AsciiArtPixel>,
-        width: u32,
-        height: u32,
-        colored: bool,
-    ) -> RawAsciiArt {
-        RawAsciiArt {
-            characters,
-            width,
-            height,
-            colored,
-        }
+impl fmt::Display for AsciiArt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[cfg(feature = "rayon")]
+        let iter = self.characters.par_iter();
+        #[cfg(not(feature = "rayon"))]
+        let iter = self.characters.iter();
+
+        let characters = iter
+            .map(|ascii_character| {
+                if self.colored {
+                    ascii_character
+                        .character
+                        .to_string()
+                        .truecolor(ascii_character.r, ascii_character.g, ascii_character.b)
+                        .to_string()
+                } else {
+                    ascii_character.character.to_string()
+                }
+            })
+            .collect::<Vec<String>>();
+
+        #[cfg(feature = "rayon")]
+        let chunks = characters.par_chunks(self.width.try_into().unwrap());
+        #[cfg(not(feature = "rayon"))]
+        let chunks = characters.chunks(self.width.try_into().unwrap());
+
+        let text = chunks
+            .map(|line| line.join(""))
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        write!(f, "{}", text)
     }
 }
 
-/// ASCII art conversion result
-#[derive(Debug, Clone)]
-pub struct AsciiArt {
-    pub text: String,
-    pub width: u32,
-    pub height: u32,
-    pub colored: bool,
-}
-
 impl AsciiArt {
-    pub fn new(text: String, width: u32, height: u32, colored: bool) -> AsciiArt {
+    pub fn new(characters: Vec<AsciiArtPixel>, width: u32, height: u32, colored: bool) -> AsciiArt {
         AsciiArt {
-            text,
+            characters,
             width,
             height,
             colored,
@@ -201,18 +211,11 @@ impl fmt::Display for SizeError {
 #[derive(Debug, Clone)]
 pub enum AsciiArtConverterError {
     AsciiStringError(AsciiStringError),
-    SizeError(SizeError),
 }
 
 impl From<AsciiStringError> for AsciiArtConverterError {
     fn from(e: AsciiStringError) -> AsciiArtConverterError {
         AsciiArtConverterError::AsciiStringError(e)
-    }
-}
-
-impl From<SizeError> for AsciiArtConverterError {
-    fn from(e: SizeError) -> AsciiArtConverterError {
-        AsciiArtConverterError::SizeError(e)
     }
 }
 
@@ -222,7 +225,6 @@ impl fmt::Display for AsciiArtConverterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             AsciiArtConverterError::AsciiStringError(err) => err.fmt(f),
-            AsciiArtConverterError::SizeError(err) => err.fmt(f),
         }
     }
 }
@@ -236,7 +238,7 @@ pub struct AsciiArtConverterOptions {
 
 /// Converter of images to ASCII art
 pub trait AsciiArtConverter {
-    /// Convert image to raw ASCII art
+    /// Convert image to an ASCII art
     ///
     /// # Examples
     ///
@@ -255,18 +257,13 @@ pub trait AsciiArtConverter {
         &self,
         options: &AsciiArtConverterOptions,
     ) -> Result<AsciiArt, AsciiArtConverterError>;
-    /// Convert image to ASCII art (raw)
-    fn raw_ascii_art(
-        &self,
-        options: &AsciiArtConverterOptions,
-    ) -> Result<RawAsciiArt, AsciiArtConverterError>;
 }
 
 impl AsciiArtConverter for DynamicImage {
-    fn raw_ascii_art(
+    fn ascii_art(
         &self,
         options: &AsciiArtConverterOptions,
-    ) -> Result<RawAsciiArt, AsciiArtConverterError> {
+    ) -> Result<AsciiArt, AsciiArtConverterError> {
         let img_buffer = self.to_rgba8();
 
         #[cfg(feature = "rayon")]
@@ -275,57 +272,16 @@ impl AsciiArtConverter for DynamicImage {
         let chunks = img_buffer.as_raw().chunks(4);
 
         let characters = chunks
-            .map(|raw| AsciiArtPixel::new(raw[0], raw[1], raw[2], raw[3], &options.ascii_string))
+            .map(|rgba| {
+                AsciiArtPixel::new(rgba[0], rgba[1], rgba[2], rgba[3], &options.ascii_string)
+            })
             .collect::<Result<Vec<AsciiArtPixel>, AsciiStringError>>()?;
 
-        Ok(RawAsciiArt::new(
+        Ok(AsciiArt::new(
             characters,
             self.width(),
             self.height(),
             options.colored,
-        ))
-    }
-
-    fn ascii_art(
-        &self,
-        options: &AsciiArtConverterOptions,
-    ) -> Result<AsciiArt, AsciiArtConverterError> {
-        let raw_ascii_art = self.raw_ascii_art(options)?;
-
-        #[cfg(feature = "rayon")]
-        let iter = raw_ascii_art.characters.into_par_iter();
-        #[cfg(not(feature = "rayon"))]
-        let iter = raw_ascii_art.characters.into_iter();
-
-        let characters = iter
-            .map(|ascii_character| {
-                if options.colored {
-                    ascii_character
-                        .character
-                        .to_string()
-                        .truecolor(ascii_character.r, ascii_character.g, ascii_character.b)
-                        .to_string()
-                } else {
-                    ascii_character.character.to_string()
-                }
-            })
-            .collect::<Vec<String>>();
-
-        #[cfg(feature = "rayon")]
-        let chunks = characters.par_chunks(raw_ascii_art.width.try_into().unwrap());
-        #[cfg(not(feature = "rayon"))]
-        let chunks = characters.chunks(raw_ascii_art.width.try_into().unwrap());
-
-        let text = chunks
-            .map(|line| line.join(""))
-            .collect::<Vec<String>>()
-            .join("\n");
-
-        Ok(AsciiArt::new(
-            text,
-            raw_ascii_art.width,
-            raw_ascii_art.height,
-            raw_ascii_art.colored,
         ))
     }
 }

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -4,20 +4,14 @@
 //!
 //! ## Demo
 //!
-//! ```rust
+//! ```ignore
 #![doc = include_str!("../examples/demo.rs")]
 //! ```
 //!
 //! ## Colored
 //!
-//! ```rust
+//! ```ignore
 #![doc = include_str!("../examples/demo.rs")]
-//! ```
-//!
-//! ## Using player
-//!
-//! ```rust
-#![doc = include_str!("../examples/player.rs")]
 //! ```
 
 use colored::Colorize;
@@ -38,7 +32,7 @@ pub const DEFAULT_ASCII_STRING: &str = " .,:;+*?%S#@";
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use tapciify::get_lightness;
 ///
 /// let result = get_lightness(255, 255, 255, 255);
@@ -60,6 +54,7 @@ pub fn get_lightness(r: u8, g: u8, b: u8, a: u8) -> f32 {
     ((max as f32 + min as f32) * a as f32) / 130050.0 // 130050 - we need to divide by 512, and divide by 255 from alpha
 }
 
+/// Error caused by lightness being out of ASCII string in [`ascii_character`]
 #[derive(Debug, Clone)]
 pub struct AsciiStringError;
 
@@ -75,7 +70,7 @@ impl Error for AsciiStringError {}
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use tapciify::ascii_character;
 ///
 /// let ascii_string = " *#";
@@ -97,9 +92,9 @@ pub fn ascii_character(lightness: f32, ascii_string: &str) -> Result<char, Ascii
         .ok_or(AsciiStringError)
 }
 
-/// Ascii character of RawAsciiImage
+/// ASCII character of RawAsciiImage
 #[derive(Debug, Clone)]
-pub struct AsciiCharacter {
+pub struct AsciiArtPixel {
     pub character: char,
     pub r: u8,
     pub g: u8,
@@ -107,23 +102,23 @@ pub struct AsciiCharacter {
     pub a: u8,
 }
 
-impl AsciiCharacter {
-    /// Convert RGBA and ASCII string into [`AsciiCharacter`]
+impl AsciiArtPixel {
+    /// Convert RGBA and ASCII string into [`AsciiArtPixel`]
     ///
     /// # Examples
     ///
-    /// ```rust
-    /// use tapciify::AsciiCharacter;
+    /// ```
+    /// use tapciify::AsciiArtPixel;
     ///
     /// let ascii_string = " *#";
     ///
-    /// let result = AsciiCharacter::new(255, 255, 255, 255, ascii_string)?;
+    /// let result = AsciiArtPixel::new(255, 255, 255, 255, ascii_string)?;
     /// assert_eq!(result.character, '#');
     ///
-    /// let result = AsciiCharacter::new(255, 255, 255, 0, ascii_string)?;
+    /// let result = AsciiArtPixel::new(255, 255, 255, 0, ascii_string)?;
     /// assert_eq!(result.character, ' ');
     ///
-    /// let result = AsciiCharacter::new(0, 0, 0, 255, ascii_string)?;
+    /// let result = AsciiArtPixel::new(0, 0, 0, 255, ascii_string)?;
     /// assert_eq!(result.character, ' ');
     /// # Ok::<(), tapciify::AsciiStringError>(())
     /// `````
@@ -133,12 +128,12 @@ impl AsciiCharacter {
         b: u8,
         a: u8,
         ascii_string: &str,
-    ) -> Result<AsciiCharacter, AsciiStringError> {
+    ) -> Result<AsciiArtPixel, AsciiStringError> {
         let lightness = get_lightness(r, g, b, a);
 
         let character = ascii_character(lightness, ascii_string)?;
 
-        Ok(AsciiCharacter {
+        Ok(AsciiArtPixel {
             character,
             r,
             g,
@@ -148,10 +143,10 @@ impl AsciiCharacter {
     }
 }
 
-/// Raw Ascii art conversion result
+/// Raw ASCII art conversion result
 #[derive(Debug, Clone)]
 pub struct RawAsciiArt {
-    pub characters: Vec<AsciiCharacter>,
+    pub characters: Vec<AsciiArtPixel>,
     pub width: u32,
     pub height: u32,
     pub colored: bool,
@@ -159,7 +154,7 @@ pub struct RawAsciiArt {
 
 impl RawAsciiArt {
     pub fn new(
-        characters: Vec<AsciiCharacter>,
+        characters: Vec<AsciiArtPixel>,
         width: u32,
         height: u32,
         colored: bool,
@@ -173,7 +168,7 @@ impl RawAsciiArt {
     }
 }
 
-/// Ascii art conversion result
+/// ASCII art conversion result
 #[derive(Debug, Clone)]
 pub struct AsciiArt {
     pub text: String,
@@ -202,90 +197,77 @@ impl fmt::Display for SizeError {
     }
 }
 
+/// Error caused by [`AsciiArtConverter`]
 #[derive(Debug, Clone)]
-pub enum AsciiConverterError {
+pub enum AsciiArtConverterError {
     AsciiStringError(AsciiStringError),
     SizeError(SizeError),
 }
 
-impl From<AsciiStringError> for AsciiConverterError {
-    fn from(e: AsciiStringError) -> AsciiConverterError {
-        AsciiConverterError::AsciiStringError(e)
+impl From<AsciiStringError> for AsciiArtConverterError {
+    fn from(e: AsciiStringError) -> AsciiArtConverterError {
+        AsciiArtConverterError::AsciiStringError(e)
     }
 }
 
-impl From<SizeError> for AsciiConverterError {
-    fn from(e: SizeError) -> AsciiConverterError {
-        AsciiConverterError::SizeError(e)
+impl From<SizeError> for AsciiArtConverterError {
+    fn from(e: SizeError) -> AsciiArtConverterError {
+        AsciiArtConverterError::SizeError(e)
     }
 }
 
-impl Error for AsciiConverterError {}
+impl Error for AsciiArtConverterError {}
 
-impl fmt::Display for AsciiConverterError {
+impl fmt::Display for AsciiArtConverterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            AsciiConverterError::AsciiStringError(err) => err.fmt(f),
-            AsciiConverterError::SizeError(err) => err.fmt(f),
+            AsciiArtConverterError::AsciiStringError(err) => err.fmt(f),
+            AsciiArtConverterError::SizeError(err) => err.fmt(f),
         }
     }
 }
 
-/// Converter of images to ASCII art
-#[derive(Debug, Clone)]
-pub struct AsciiConverter {}
-
 /// Options for converter of images to ASCII art
 #[derive(Debug, Clone)]
-pub struct AsciiConverterOptions {
+pub struct AsciiArtConverterOptions {
     pub ascii_string: String,
     pub colored: bool,
 }
 
-impl AsciiConverter {
+/// Converter of images to ASCII art
+pub trait AsciiArtConverter {
     /// Convert image to raw ASCII art
     ///
     /// # Examples
     ///
-    /// Regular:
+    /// Demo:
     ///
-    /// ```rust
-    /// use tapciify::{AsciiConverter, AsciiConverterOptions};
-    ///
-    /// let path = "./assets/examples/original.webp";
-    /// let img = image::open(path)?;
-    ///
-    /// let options = AsciiConverterOptions {
-    ///     ..Default::default()
-    /// };
-    ///
-    /// assert!(AsciiConverter::convert_raw(&img, &options).is_ok());
-    ///
-    /// # Ok::<(), image::ImageError>(())
+    /// ```
+    #[doc = include_str!("../examples/demo.rs")]
     /// ````
     ///
     /// Colored:
     ///
-    /// ```rust
-    /// use tapciify::{AsciiConverter, AsciiConverterOptions};
-    ///
-    /// let path = "./assets/examples/original.webp";
-    /// let img = image::open(path)?;
-    ///
-    /// let options = AsciiConverterOptions {
-    ///     colored: true,
-    ///     ..Default::default()
-    /// };
-    ///
-    /// assert!(AsciiConverter::convert_raw(&img, &options).is_ok());
-    ///
-    /// # Ok::<(), image::ImageError>(())
+    /// ```
+    #[doc = include_str!("../examples/colored.rs")]
     /// ````
-    pub fn convert_raw(
-        img: &DynamicImage,
-        options: &AsciiConverterOptions,
-    ) -> Result<RawAsciiArt, AsciiConverterError> {
-        let img_buffer = img.to_rgba8();
+    fn ascii_art(
+        &self,
+        options: &AsciiArtConverterOptions,
+    ) -> Result<AsciiArt, AsciiArtConverterError>;
+    /// Convert image to ASCII art (raw)
+    fn raw_ascii_art(
+        &self,
+        options: &AsciiArtConverterOptions,
+    ) -> Result<RawAsciiArt, AsciiArtConverterError>;
+}
+
+impl AsciiArtConverter for DynamicImage {
+    fn raw_ascii_art(
+        &self,
+        options: &AsciiArtConverterOptions,
+    ) -> Result<RawAsciiArt, AsciiArtConverterError> {
+        let img_buffer = self.to_rgba8();
 
         #[cfg(feature = "rayon")]
         let chunks = img_buffer.as_raw().par_chunks(4);
@@ -293,23 +275,22 @@ impl AsciiConverter {
         let chunks = img_buffer.as_raw().chunks(4);
 
         let characters = chunks
-            .map(|raw| AsciiCharacter::new(raw[0], raw[1], raw[2], raw[3], &options.ascii_string))
-            .collect::<Result<Vec<AsciiCharacter>, AsciiStringError>>()?;
+            .map(|raw| AsciiArtPixel::new(raw[0], raw[1], raw[2], raw[3], &options.ascii_string))
+            .collect::<Result<Vec<AsciiArtPixel>, AsciiStringError>>()?;
 
         Ok(RawAsciiArt::new(
             characters,
-            img.width(),
-            img.height(),
+            self.width(),
+            self.height(),
             options.colored,
         ))
     }
 
-    /// Convert image to ASCII art
-    pub fn convert(
-        img: &DynamicImage,
-        options: &AsciiConverterOptions,
-    ) -> Result<AsciiArt, AsciiConverterError> {
-        let raw_ascii_art = AsciiConverter::convert_raw(img, options)?;
+    fn ascii_art(
+        &self,
+        options: &AsciiArtConverterOptions,
+    ) -> Result<AsciiArt, AsciiArtConverterError> {
+        let raw_ascii_art = self.raw_ascii_art(options)?;
 
         #[cfg(feature = "rayon")]
         let iter = raw_ascii_art.characters.into_par_iter();
@@ -349,9 +330,9 @@ impl AsciiConverter {
     }
 }
 
-impl Default for AsciiConverterOptions {
-    fn default() -> AsciiConverterOptions {
-        AsciiConverterOptions {
+impl Default for AsciiArtConverterOptions {
+    fn default() -> AsciiArtConverterOptions {
+        AsciiArtConverterOptions {
             ascii_string: DEFAULT_ASCII_STRING.to_owned(),
             colored: false,
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,7 +91,7 @@ impl fmt::Display for GlobToPathsError {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use tapciify::cli::glob_to_paths;
 ///
 /// let paths = vec!["assets\\examples\\*.webp".to_owned()];

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,6 +53,7 @@ pub struct Cli {
     pub font_ratio: f64,
 }
 
+/// Error caused by [`glob_to_paths`]
 #[cfg(target_family = "windows")]
 #[derive(Debug)]
 pub enum GlobToPathsError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 //! > **Tool to convert your images into ASCII art**
 //!
 //! Useful functions, when using as lib
-//! - [`AsciiConverter::convert`]
-//! - [`AsciiConverter::convert_raw`]
+//! - [`AsciiArtConverter::ascii_art`]
 //! - [`CustomRatioResize`]
 //!
 //! ## Installation
@@ -39,14 +38,14 @@
 //!
 //! ## Demo
 //!
-//! ```rust
+//! ```ignore
 #![doc = include_str!("../examples/demo.rs")]
 //! ```
 //!
 //! ## Colored
 //!
-//! ```rust
-#![doc = include_str!("../examples/demo.rs")]
+//! ```ignore
+#![doc = include_str!("../examples/colored.rs")]
 //! ```
 
 pub mod ascii;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Useful functions, when using as lib
 //! - [`AsciiArtConverter::ascii_art`]
-//! - [`CustomRatioResize`]
+//! - [`CustomRatioResize::resize_custom_ratio`]
 //!
 //! ## Installation
 //!
@@ -38,13 +38,13 @@
 //!
 //! ## Demo
 //!
-//! ```ignore
+//! ```
 #![doc = include_str!("../examples/demo.rs")]
 //! ```
 //!
 //! ## Colored
 //!
-//! ```ignore
+//! ```
 #![doc = include_str!("../examples/colored.rs")]
 //! ```
 
@@ -58,7 +58,10 @@ pub mod player;
 pub mod cli;
 
 #[doc(inline)]
-pub use ascii::*;
+pub use ascii::{
+    AsciiArt, AsciiArtConverter, AsciiArtConverterError, AsciiArtConverterOptions, AsciiArtPixel,
+    AsciiStringError, SizeError, DEFAULT_ASCII_STRING,
+};
 #[doc(inline)]
 pub use resize::{CustomRatioResize, DEFAULT_FONT_RATIO};
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -80,6 +80,7 @@ impl From<AsciiPlayerOptions> for AsciiArtConverterOptions {
     }
 }
 
+/// Error caused by [`AsciiPlayer`]
 #[derive(Debug)]
 pub enum AsciiPlayerError {
     Image(ImageError),

--- a/src/player.rs
+++ b/src/player.rs
@@ -3,14 +3,14 @@
 //!
 //! # Examples
 //!
-//! ```rust
+//! ```
 #![doc = include_str!("../examples/player.rs")]
 //! ```
 
 use crate::{
     ascii::{
-        AsciiArt, AsciiConverter, AsciiConverterError, AsciiConverterOptions, AsciiStringError,
-        DEFAULT_ASCII_STRING,
+        AsciiArt, AsciiArtConverter, AsciiArtConverterError, AsciiArtConverterOptions,
+        AsciiStringError, DEFAULT_ASCII_STRING,
     },
     CustomRatioResize, DEFAULT_FONT_RATIO,
 };
@@ -26,7 +26,7 @@ use rayon::prelude::*;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use tapciify::player::calculate_frame_time;
 ///
 /// let result = calculate_frame_time(Some(20.0));
@@ -71,9 +71,9 @@ impl Default for AsciiPlayerOptions {
     }
 }
 
-impl From<AsciiPlayerOptions> for AsciiConverterOptions {
-    fn from(o: AsciiPlayerOptions) -> AsciiConverterOptions {
-        AsciiConverterOptions {
+impl From<AsciiPlayerOptions> for AsciiArtConverterOptions {
+    fn from(o: AsciiPlayerOptions) -> AsciiArtConverterOptions {
+        AsciiArtConverterOptions {
             ascii_string: o.ascii_string,
             colored: o.colored,
         }
@@ -83,7 +83,7 @@ impl From<AsciiPlayerOptions> for AsciiConverterOptions {
 #[derive(Debug)]
 pub enum AsciiPlayerError {
     Image(ImageError),
-    AsciiConverter(AsciiConverterError),
+    AsciiConverter(AsciiArtConverterError),
     AsciiString(AsciiStringError),
 }
 
@@ -93,8 +93,8 @@ impl From<ImageError> for AsciiPlayerError {
     }
 }
 
-impl From<AsciiConverterError> for AsciiPlayerError {
-    fn from(e: AsciiConverterError) -> AsciiPlayerError {
+impl From<AsciiArtConverterError> for AsciiPlayerError {
+    fn from(e: AsciiArtConverterError) -> AsciiPlayerError {
         AsciiPlayerError::AsciiConverter(e)
     }
 }
@@ -130,7 +130,7 @@ impl AsciiPlayer {
     ) -> Result<(), AsciiPlayerError> {
         let mut first_frame = true;
 
-        let converter_options = AsciiConverterOptions::from(options.to_owned());
+        let converter_options = AsciiArtConverterOptions::from(options.to_owned());
 
         loop {
             for path in paths.iter() {
@@ -142,7 +142,7 @@ impl AsciiPlayer {
                     options.font_ratio,
                     options.filter,
                 );
-                let ascii_image = AsciiConverter::convert(&img, &converter_options)?;
+                let ascii_image = img.ascii_art(&converter_options)?;
 
                 if !first_frame {
                     execute!(stdout(), MoveUp(ascii_image.height.try_into().unwrap()))
@@ -171,7 +171,7 @@ impl AsciiPlayer {
     ) -> Result<Vec<AsciiArt>, AsciiPlayerError> {
         let pb = ProgressBar::new(paths.len().try_into().unwrap());
 
-        let converter_options = AsciiConverterOptions::from(options.to_owned());
+        let converter_options = AsciiArtConverterOptions::from(options.to_owned());
 
         #[cfg(feature = "rayon")]
         let iter = paths.into_par_iter();
@@ -186,7 +186,7 @@ impl AsciiPlayer {
                     options.font_ratio,
                     options.filter,
                 );
-                let ascii_image = AsciiConverter::convert(&img, &converter_options)?;
+                let ascii_image = img.ascii_art(&converter_options)?;
 
                 pb.inc(1);
 
@@ -236,7 +236,7 @@ impl AsciiPlayer {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use tapciify::{AsciiPlayer, AsciiPlayerOptions};
     ///
     /// let paths = vec!["./assets/examples/original.webp".to_owned()];

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -22,7 +22,7 @@ pub trait CustomRatioResize {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use image::imageops::FilterType;
     /// use tapciify::{CustomRatioResize, DEFAULT_FONT_RATIO};
     ///


### PR DESCRIPTION
New code example:

```rust
use image::imageops::FilterType;
use std::error::Error;
use tapciify::{
    AsciiArtConverter, AsciiArtConverterOptions, CustomRatioResize, DEFAULT_FONT_RATIO,
};

fn main() -> Result<(), Box<dyn Error>> {
    let img = image::open("./assets/examples/original.webp")?;

    let result = img
        .resize_custom_ratio(Some(64), None, DEFAULT_FONT_RATIO, FilterType::Triangle)
        .ascii_art(&AsciiArtConverterOptions {
            // Put your other options here
            ..Default::default()
        })?;

    println!("{}", result);

    Ok(())
}
```