### PR TITLE
Remove short argument for bg-str

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,7 +58,7 @@ pub struct Cli {
     #[clap(short, long, action)]
     pub braille: bool,
     /// Use text for background on light pixels
-    #[clap(short, long)]
+    #[clap(long)]
     pub background_string: Option<String>,
 }
 


### PR DESCRIPTION
```
Command tapciify: Short option names must be unique for each argument, but '-b' is in use by both 'braille' and 'background_string'
```